### PR TITLE
feat: 프로메테우스 배포용 파일 정의

### DIFF
--- a/raspberry-pi/docker-compose.yaml
+++ b/raspberry-pi/docker-compose.yaml
@@ -1,0 +1,21 @@
+# 위치: /grad-project/docker-compose.yaml
+services:
+  prometheus:
+    image: prom/prometheus
+    container_name: prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yaml'
+    ports:
+      - 9090:9090
+    restart: unless-stopped
+    volumes:
+      - ./prometheus:/etc/prometheus
+      - prom_data:/prometheus
+    networks:
+      - monitoring
+volumes:
+  prom_data:
+
+networks:
+  monitoring:
+    driver: bridge

--- a/raspberry-pi/nginx/nginx.conf
+++ b/raspberry-pi/nginx/nginx.conf
@@ -1,0 +1,24 @@
+http {
+
+  include mime.types;
+
+  set_real_ip_from        0.0.0.0/0;
+  real_ip_recursive       on;
+  real_ip_header          X-Forward-For;
+  limit_req_zone          $binary_remote_addr zone=mylimit:10m rate=10r/s;
+
+  upstream docker-prometheus {
+    server prometheus:9090;
+  }
+
+  server {
+    listen 80;
+    server_name [prometheus.daily-cotidie.com](http://prometheus.daily-cotidie.com/);
+    root /proxy;
+    limit_req zone=mylimit burst=70 nodelay;
+
+    location / {
+       proxy_pass http://docker-prometheus; 
+    }
+  }
+}

--- a/raspberry-pi/prometheus/prometheus.yaml
+++ b/raspberry-pi/prometheus/prometheus.yaml
@@ -1,0 +1,20 @@
+# 위치: /grad-project/prometheus/prometheus.yaml
+global:
+  scrape_interval: 30s # set the scraping interval to 30 seconds.
+  evaluation_interval: 15s # the interval for evaluating rules.
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+          # - alertmanager:9093
+
+rule_files:
+  # - "first_rules.yml"
+
+scrape_configs:
+  - job_name: "prometheus"
+
+    # metrics_path defaults to '/metrics'
+    static_configs:
+      - targets: ["localhost:9090"]


### PR DESCRIPTION
# 변경내역
- 라우터로부터 메트릭을 수집받기 위해 프로메테우스를 도커로 배포합니다.
- 라즈베리파이 한 곳에서 Prometheus, Grafana 모두 배포하기 위해 nginx를 정의했습니다.

# 스크린샷
(없음)

# 비고
(없음)

# 연관 이슈
closes #1 