### PR TITLE
feat: API 요청 시 job_name 파라미터 제거

### DIFF
--- a/raspberry-pi/prometheus-manager/handler.go
+++ b/raspberry-pi/prometheus-manager/handler.go
@@ -6,6 +6,10 @@ import (
 	"net/http"
 )
 
+const (
+	JOBNAME_ROUTERS = "routers" // 모니터링 라우터 관리용 Job Name
+)
+
 type APIHandler interface {
 	AddTarget(rw http.ResponseWriter, req *http.Request)
 	RemoveTarget(rw http.ResponseWriter, req *http.Request)
@@ -32,7 +36,7 @@ func (ah *apiHandler) AddTarget(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	err = ah.config.AddTarget(body.JobName, body.IP)
+	err = ah.config.AddTarget(JOBNAME_ROUTERS, body.IP)
 	if err != nil {
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
 		return
@@ -59,7 +63,7 @@ func (ah *apiHandler) RemoveTarget(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	err = ah.config.RemoveTarget(body.JobName, body.IP)
+	err = ah.config.RemoveTarget(JOBNAME_ROUTERS, body.IP)
 	if err != nil {
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
 		return
@@ -86,7 +90,7 @@ func (ah *apiHandler) ListTargets(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	targets, err := ah.config.ListTargets(body.JobName)
+	targets, err := ah.config.ListTargets(JOBNAME_ROUTERS)
 	if err != nil {
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
 		return

--- a/raspberry-pi/prometheus-manager/request.go
+++ b/raspberry-pi/prometheus-manager/request.go
@@ -1,15 +1,13 @@
 package main
 
+type Empty struct{}
+
 type AddTargetRequest struct {
-	JobName string `json:"job_name"`
-	IP      string `json:"ip"`
+	IP string `json:"ip"`
 }
 
-type ListTargetRequest struct {
-	JobName string `json:"job_name"`
-}
+type ListTargetRequest Empty
 
 type RemoveTargetRequest struct {
-	JobName string `json:"job_name"`
-	IP      string `json:"ip"`
+	IP string `json:"ip"`
 }


### PR DESCRIPTION
- `GET /api/target/list`, `POST /api/target/add`, `POST /api/target/remove`의 요청 파라미터 중 `job_name` 항목 제거 