### PR TITLE
feat: 라우터 메트릭 수집 등록 스크립트 추가

### DIFF
--- a/router_setup/register_router
+++ b/router_setup/register_router
@@ -9,12 +9,12 @@ PORT=$2
 API_REGISTER="prometheus-manager.daily-cotidie.com/api/target/add"
 
 if [[ -z "$IP" ]]; then
-    printf '[register_router] 추가할 IP가 전달되지 않았습니다. \n'
+    printf '[register_router] No IP address is delivered. \n'
     exit 1;
 fi
 
 if [[ -z "$PORT" ]]; then
-    printf '[register_router] 메트릭 포트번호가 전달되지 않았습니다. \n'
+    printf '[register_router] No port number for metrics export is delivered. \n'
     exit 1;
 fi
 

--- a/router_setup/router_setup_2
+++ b/router_setup/router_setup_2
@@ -10,7 +10,8 @@ sleep 1
 # package install part
 
 opkg update
-opkg install prometheus-node-exporter-lua  \
+opkg install curl \
+prometheus-node-exporter-lua  \
 prometheus-node-exporter-lua-nat_traffic \
 prometheus-node-exporter-lua-netstat \
 prometheus-node-exporter-lua-openwrt \
@@ -22,7 +23,7 @@ sleep 1
 
 installed_list=$(opkg list_installed)
 check_strings() {
-  for string in "prometheus-node-exporter-lua" "prometheus-node-exporter-lua-nat_traffic" "prometheus-node-exporter-lua-netstat" \
+  for string in "curl" "prometheus-node-exporter-lua" "prometheus-node-exporter-lua-nat_traffic" "prometheus-node-exporter-lua-netstat" \
 "prometheus-node-exporter-lua-openwrt" "prometheus-node-exporter-lua-wifi" "prometheus-node-exporter-lua-wifi_stations" \
 "hostapd-utils" "qos-scripts" ; do
     if ! opkg list_installed | grep -q "$string" ; then
@@ -33,6 +34,7 @@ check_strings() {
   echo "*All packages* were installed successfully"
   return 0
 }
+
 if ! check_strings ; then
     echo "Unexpected error occured. packages weren't installed successfully"
         exit
@@ -40,21 +42,18 @@ fi
 sleep 1
 
 # enable OpenWrt_wifi
-
 uci set wireless.radio0.disabled=0
 uci set wireless.default_radio0.ssid=$1
 uci commit wireless
 sleep 1
 
 # enable prometheus metric collect
-
 uci set prometheus-node-exporter-lua.main.listen_interface='*'
 uci commit prometheus-node-exporter-lua
 /etc/init.d/prometheus-node-exporter-lua restart
 sleep 1
 
 # QoS Config file Setting
-
 uci set qos.wan.upload='40000'
 uci set qos.wan.upload='40000'
 uci commit qos

--- a/setup_install
+++ b/setup_install
@@ -19,8 +19,8 @@ if [ ! -d "$SETUP_NAME" ]; then
 fi 
 
 wget https://raw.githubusercontent.com/wa-sin-sang-dam/wasin-infra/refs/heads/main/router_setup/main_config        -O $(echo /$SETUP_NAME/main_config)
-wget https://raw.githubusercontent.com/wa-sin-sang-dam/wasin-infra/refs/heads/main/router_setup/check_refresh  
-wget https://raw.githubusercontent.com/KwonNaeHyeon/wasin-infra/refs/heads/main/router_setup/network_refresh    -O $(echo /$SETUP_NAME/check_refresh)
+wget https://raw.githubusercontent.com/wa-sin-sang-dam/wasin-infra/refs/heads/main/router_setup/check_refresh      -O $(echo /$SETUP_NAME/check_refresh)
+wget https://raw.githubusercontent.com/KwonNaeHyeon/wasin-infra/refs/heads/main/router_setup/network_refresh       -O $(echo /$SETUP_NAME/network_refresh)
 wget https://raw.githubusercontent.com/wa-sin-sang-dam/wasin-infra/refs/heads/main/router_setup/make_forwarding    -O $(echo /$SETUP_NAME/make_forwarding) 
 wget https://raw.githubusercontent.com/wa-sin-sang-dam/wasin-infra/refs/heads/main/router_setup/port_config        -O $(echo /$SETUP_NAME/port_config)
 wget https://raw.githubusercontent.com/wa-sin-sang-dam/wasin-infra/refs/heads/main/router_setup/register_router    -O $(echo /$SETUP_NAME/register_router)

--- a/setup_install
+++ b/setup_install
@@ -19,7 +19,7 @@ if [ ! -d "$SETUP_NAME" ]; then
 fi 
 
 wget https://raw.githubusercontent.com/wa-sin-sang-dam/wasin-infra/refs/heads/main/router_setup/main_config        -O $(echo /$SETUP_NAME/main_config)
-wget https://raw.githubusercontent.com/wa-sin-sang-dam/wasin-infra/refs/heads/main/router_setup/check_refresh      -O $(echo /$SETUP_NAME/check_refresh)
+wget https://raw.githubusercontent.com/wa-sin-sang-dam/wasin-infra/refs/heads/main/router_setup/check_status       -O $(echo /$SETUP_NAME/check_status)
 wget https://raw.githubusercontent.com/KwonNaeHyeon/wasin-infra/refs/heads/main/router_setup/network_refresh       -O $(echo /$SETUP_NAME/network_refresh)
 wget https://raw.githubusercontent.com/wa-sin-sang-dam/wasin-infra/refs/heads/main/router_setup/make_forwarding    -O $(echo /$SETUP_NAME/make_forwarding) 
 wget https://raw.githubusercontent.com/wa-sin-sang-dam/wasin-infra/refs/heads/main/router_setup/port_config        -O $(echo /$SETUP_NAME/port_config)

--- a/setup_install
+++ b/setup_install
@@ -1,5 +1,6 @@
 DIR_NAME="/root/profile_execute"
 LOG_NAME="/root/log"
+SETUP_NAME="/root/setup"
 
 if [ ! -d "$DIR_NAME" ]; then
     echo "Created new profile directory"
@@ -12,25 +13,24 @@ if [ ! -d "$LOG_NAME" ]; then
     touch "/root/log/log_profile"
 fi
 
-wget https://raw.githubusercontent.com/KwonNaeHyeon/wasin-infra/main/router_setup/port_config
-wget https://raw.githubusercontent.com/KwonNaeHyeon/wasin-infra/main/router_setup/router_setup_1
-wget https://raw.githubusercontent.com/KwonNaeHyeon/wasin-infra/main/router_setup/router_setup_2
-wget https://raw.githubusercontent.com/KwonNaeHyeon/wasin-infra/main/router_setup/router_basic_setup
-wget https://raw.githubusercontent.com/KwonNaeHyeon/wasin-infra/refs/heads/main/router_setup/check_status
-wget https://raw.githubusercontent.com/KwonNaeHyeon/wasin-infra/refs/heads/main/router_setup/network_refresh
-wget https://raw.githubusercontent.com/KwonNaeHyeon/wasin-infra/main/router_setup/main_config
-wget https://raw.githubusercontent.com/KwonNaeHyeon/wasin-infra/main/router_setup/make_forwarding
+if [ ! -d "$SETUP_NAME" ]; then
+    echo "Created new log directory"
+    mkdir $SETUP_NAME
+fi 
 
-chmod +x port_config
-chmod +x router_basic_setup
-chmod +x check_status
-chmod +x network_refresh
-chmod +x main_config
-chmod +x make_forwarding
-chmod +x router_setup_*
+wget https://raw.githubusercontent.com/wa-sin-sang-dam/wasin-infra/refs/heads/main/router_setup/main_config        -O $(echo /$SETUP_NAME/main_config)
+wget https://raw.githubusercontent.com/wa-sin-sang-dam/wasin-infra/refs/heads/main/router_setup/check_refresh  
+wget https://raw.githubusercontent.com/KwonNaeHyeon/wasin-infra/refs/heads/main/router_setup/network_refresh    -O $(echo /$SETUP_NAME/check_refresh)
+wget https://raw.githubusercontent.com/wa-sin-sang-dam/wasin-infra/refs/heads/main/router_setup/make_forwarding    -O $(echo /$SETUP_NAME/make_forwarding) 
+wget https://raw.githubusercontent.com/wa-sin-sang-dam/wasin-infra/refs/heads/main/router_setup/port_config        -O $(echo /$SETUP_NAME/port_config)
+wget https://raw.githubusercontent.com/wa-sin-sang-dam/wasin-infra/refs/heads/main/router_setup/register_router    -O $(echo /$SETUP_NAME/register_router)
+wget https://raw.githubusercontent.com/wa-sin-sang-dam/wasin-infra/refs/heads/main/router_setup/router_basic_setup -O $(echo /$SETUP_NAME/router_basic_setup)
+wget https://raw.githubusercontent.com/wa-sin-sang-dam/wasin-infra/refs/heads/main/router_setup/router_setup_1     -O $(echo /$SETUP_NAME/router_setup_1)
+wget https://raw.githubusercontent.com/wa-sin-sang-dam/wasin-infra/refs/heads/main/router_setup/router_setup_2     -O $(echo /$SETUP_NAME/router_setup_2)
+
+chmod a+x $(echo "$SETUP_NAME/*")
 
 # after, make sure that router_info file is in $DIR_NAME directory
-
 wget -O $(echo $DIR_NAME/profile_connective) https://raw.githubusercontent.com/KwonNaeHyeon/wasin-infra/main/router_profile/profile_connective
 wget -O $(echo $DIR_NAME/profile_default) https://raw.githubusercontent.com/KwonNaeHyeon/wasin-infra/main/router_profile/profile_default
 wget -O $(echo $DIR_NAME/profile_pow_saving) https://raw.githubusercontent.com/KwonNaeHyeon/wasin-infra/main/router_profile/profile_pow_saving


### PR DESCRIPTION
- setup_install의 다운로드 링크를 공용 레포지토리로 수정
- setup 관련 스크립트는 setup 폴더에 다운로드하도록 수정
- 기본 설치 패키지에 `curl` 추가
- router_register를 통해 라즈베리파이(프로메테우스)에 메트릭을 수집하도록 요청